### PR TITLE
NC-108-Bug Report-Missing Topic Link in Article Card and ArticlePage

### DIFF
--- a/src/components/article-card/article-card.jsx
+++ b/src/components/article-card/article-card.jsx
@@ -17,7 +17,9 @@ function ArticleCard({ article, handleVoteChange }) {
           <Link to={`/articles/${article.article_id}`}>
             <h2>{article.title}</h2>
           </Link>
-          <p className="article-tag">{`topic: ${article.topic}`}</p>
+          <Link to={`/articles/${article.article_id}`}>
+            <p className="article-tag">{`topic: ${article.topic}`}</p>
+          </Link>
           <div className="article-meta">
             <span>
               <strong>Author:</strong> {article.author} —{" "}

--- a/src/components/article-page/article-page.jsx
+++ b/src/components/article-page/article-page.jsx
@@ -54,7 +54,9 @@ function ArticlePage() {
           </div>
           <hr aria-orientation="horizontal" className="divider"></hr>
           <div className="articleContent">
-            <p className="tagText">Topic: {article.topic}</p>
+            <Link to="/">
+              <p className="tagText">Topic: {article.topic}</p>
+            </Link>
             <h1>{article.title}</h1>
             <p>
               <strong>Author:</strong> {article.author}


### PR DESCRIPTION
**Content**
NC-108 -https://trello.com/c/4h4tlKlK/9-nc-108-bug-report-missing-topic-link-in-article-card-and-appjs-route-path

Issue Description: The topic link is not present in the article card component, and article page component. As a result, clicking on a topic does not navigate to the correct page.

Add the topic link to the article card:

Add the topic link to the article page.

